### PR TITLE
Fix issue with smartmobile and login screen

### DIFF
--- a/src/HordeInstaller.php
+++ b/src/HordeInstaller.php
@@ -137,6 +137,8 @@ class HordeInstaller extends LibraryInstaller
                         realpath($this->getInstallPath($package))
                     );
                     $registryLocalFileContent .=
+                    '$this->applications[\'horde\'][\'fileroot\'] = $app_fileroot;' . PHP_EOL .
+                    '$this->applications[\'horde\'][\'webroot\'] = $app_webroot;' . PHP_EOL .
                     '$this->applications[\'horde\'][\'jsfs\'] = $this->applications[\'horde\'][\'fileroot\'] . \'/../js/horde/\';' . PHP_EOL .
                     '$this->applications[\'horde\'][\'jsuri\'] = $this->applications[\'horde\'][\'webroot\'] . \'/../js/horde/\';';
                     file_put_contents($registryLocalFilePath, $registryLocalFileContent);


### PR DESCRIPTION
Due to order of process, horde['webroot'] and horde['fileroot'] may not yet be defined at the time 00-horde is loaded. This leads to the cacher not able to include jquery related js files and breaks smartmobile and login screen.