### PR TITLE
composer-plugin-api 2.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "class": "Horde\\Composer\\HordeInstallerPlugin"
     },
     "require": {
-        "composer-plugin-api": "^1.0|~2.0"
+        "composer-plugin-api": "^1.0|^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.3|~2.0"
+        "composer/composer": "^1.3|^2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "class": "Horde\\Composer\\HordeInstallerPlugin"
     },
     "require": {
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0|~2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.3"
+        "composer/composer": "^1.3|~2.0"
     }
 }

--- a/src/HordeInstallerPlugin.php
+++ b/src/HordeInstallerPlugin.php
@@ -13,4 +13,15 @@ class HordeInstallerPlugin implements PluginInterface
         $installer = new HordeInstaller($io, $composer);
         $composer->getInstallationManager()->addInstaller($installer);
     }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        $installer = new HordeInstaller($io, $composer);
+        $composer->getInstallationManager()->removeInstaller($installer);
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        return;
+    }
 }


### PR DESCRIPTION
This allows you to install horde libraries using Composer 2. 

It resolves the below error:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - horde/horde-installer-plugin dev-master requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
    - horde/imap_client dev-master requires horde/horde-installer-plugin dev-master -> satisfiable by horde/horde-installer-plugin[dev-master].
    - Root composer.json requires horde/imap_client dev-master -> satisfiable by horde/imap_client[dev-master].

You are using Composer 2, which some of your plugins seem to be incompatible with. Make sure you update your plugins or report a plugin-issue to ask them to support Composer 2.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```