### PR TITLE
feat: Clean up obsolete PHP files after route migrations

### DIFF
--- a/src/HordeReconfigureFlow.php
+++ b/src/HordeReconfigureFlow.php
@@ -183,6 +183,10 @@ class HordeReconfigureFlow
         // ApplicationLinker must run after all changes to /vendor
         $appLinker = new ApplicationLinker($filesystem, $hordeApps, $rootPackageDir, $mode);
         $appLinker->run();
+        // Clean up obsolete PHP files from web/ dirs (after routing migrations)
+        $this->io->writeln('Cleaning up obsolete web files');
+        $webFilesCleaner = new ObsoleteWebFilesCleaner($hordeApps, $rootPackageDir, $this->io);
+        $webFilesCleaner->run();
         return 0;
     }
 }

--- a/src/ObsoleteWebFilesCleaner.php
+++ b/src/ObsoleteWebFilesCleaner.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Composer;
+
+use Composer\IO\IOInterface;
+use DirectoryIterator;
+use Horde\Composer\IOAdapter\FlowIoInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Cleans up obsolete PHP files from web directories.
+ *
+ * When apps upgrade from exposed endpoint files to routes, old PHP files
+ * in web/$app/ may no longer have corresponding source files in vendor/.
+ * This class identifies and removes such orphaned files.
+ */
+class ObsoleteWebFilesCleaner
+{
+    private string $baseDir;
+    private string $vendorDir;
+    private string $webDir;
+    private IOInterface|FlowIoInterface|null $io = null;
+    /**
+     * List of packages considered as apps
+     *
+     * @var string[]
+     */
+    private array $appPackages;
+
+    /**
+     * @param string[] $appPackages List of vendor/app strings
+     * @param string   $baseDir     Root package dir
+     * @param IOInterface|FlowIoInterface|null $io IO interface for output
+     */
+    public function __construct(array $appPackages, string $baseDir, IOInterface|FlowIoInterface|null $io = null)
+    {
+        $this->appPackages = $appPackages;
+        $this->baseDir = $baseDir;
+        $this->vendorDir = $baseDir . '/vendor';
+        $this->webDir = $baseDir . '/web';
+        $this->io = $io;
+    }
+
+    /**
+     * Remove obsolete PHP files from web directories
+     *
+     * For each app, traverse web/$app/ and check if each .php file
+     * has a corresponding file in vendor/$vendor/$app/. If not, delete it.
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+        if (!is_dir($this->webDir) || !is_readable($this->webDir)) {
+            return;
+        }
+
+        foreach ($this->appPackages as $app) {
+            if ($app === 'horde/components') {
+                continue;
+            }
+
+            [$vendor, $appName] = explode('/', $app);
+            $appWebDir = $this->webDir . '/' . $appName;
+            $appVendorDir = $this->vendorDir . '/' . $app;
+
+            // Skip if web dir doesn't exist
+            if (!is_dir($appWebDir) || !is_readable($appWebDir)) {
+                continue;
+            }
+
+            // Skip if vendor dir doesn't exist (app may be uninstalled)
+            if (!is_dir($appVendorDir) || !is_readable($appVendorDir)) {
+                continue;
+            }
+
+            $this->cleanAppDirectory($appName, $appWebDir, $appVendorDir);
+        }
+    }
+
+    /**
+     * Clean a single app's web directory
+     *
+     * @param string $appName      Application name
+     * @param string $appWebDir    Path to web/$app
+     * @param string $appVendorDir Path to vendor/$vendor/$app
+     * @return void
+     */
+    private function cleanAppDirectory(string $appName, string $appWebDir, string $appVendorDir): void
+    {
+        // Recursively iterate through web/$app
+        try {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($appWebDir, RecursiveDirectoryIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::CHILD_FIRST
+            );
+        } catch (\Exception $e) {
+            // If we can't iterate, skip this app
+            return;
+        }
+
+        foreach ($iterator as $fileInfo) {
+            // Only process .php files
+            if (!$fileInfo->isFile() || $fileInfo->getExtension() !== 'php') {
+                continue;
+            }
+
+            $webFilePath = $fileInfo->getPathname();
+
+            // Calculate relative path from app web dir
+            $relativePath = substr($webFilePath, strlen($appWebDir) + 1);
+
+            // Check if corresponding file exists in vendor
+            $vendorFilePath = $appVendorDir . '/' . $relativePath;
+
+            // If file exists in vendor (or is a symlink to it), keep it
+            if (file_exists($vendorFilePath)) {
+                continue;
+            }
+
+            // Check if it's a symlink (even if broken)
+            if (is_link($webFilePath)) {
+                // Broken symlinks should be removed
+                $this->removeFile($webFilePath, $appName, $relativePath);
+                continue;
+            }
+
+            // File exists in web/ but not in vendor/ - it's obsolete
+            $this->removeFile($webFilePath, $appName, $relativePath);
+        }
+    }
+
+    /**
+     * Remove a file and log the action
+     *
+     * @param string $filePath     Full path to file to remove
+     * @param string $appName      Application name
+     * @param string $relativePath Relative path for logging
+     * @return void
+     */
+    private function removeFile(string $filePath, string $appName, string $relativePath): void
+    {
+        if (unlink($filePath)) {
+            if ($this->io) {
+                $message = sprintf(
+                    '  <comment>Removed obsolete file:</comment> web/%s/%s',
+                    $appName,
+                    $relativePath
+                );
+
+                if ($this->io instanceof IOInterface) {
+                    $this->io->write($message, true);
+                } else {
+                    $this->io->writeln($message);
+                }
+            }
+        }
+    }
+}

--- a/test/ObsoleteWebFilesCleanerTest.php
+++ b/test/ObsoleteWebFilesCleanerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Horde\Composer\Test;
+
+use PHPUnit\Framework\TestCase;
+use Horde\Composer\ObsoleteWebFilesCleaner;
+
+/**
+ * @author     Ralf Lang <ralf.lang@ralf-lang.de>
+ * @license    http://www.horde.org/licenses/lgpl LGPL
+ * @category   Horde
+ * @package    HordeInstallerPlugin
+ * @subpackage UnitTests
+ * @coversNothing
+ */
+class ObsoleteWebFilesCleanerTest extends TestCase
+{
+    private string $fixture;
+    private string $tempDir;
+
+    public function setUp(): void
+    {
+        // Use system temp directory with unique name
+        $this->tempDir = sys_get_temp_dir() . '/horde-installer-test-' . uniqid();
+        $this->fixture = $this->tempDir;
+
+        // Create test directory structure
+        if (!is_dir($this->fixture)) {
+            mkdir($this->fixture, 0755, true);
+        }
+
+        // Create vendor/horde/turba with some files
+        $vendorDir = $this->fixture . '/vendor/horde/turba';
+        mkdir($vendorDir, 0755, true);
+        file_put_contents($vendorDir . '/index.php', '<?php // Vendor index');
+        file_put_contents($vendorDir . '/browse.php', '<?php // Vendor browse');
+
+        // Create web/turba with matching and non-matching files
+        $webDir = $this->fixture . '/web/turba';
+        mkdir($webDir, 0755, true);
+        file_put_contents($webDir . '/index.php', '<?php // Web index');
+        file_put_contents($webDir . '/browse.php', '<?php // Web browse');
+        file_put_contents($webDir . '/smartmobile.php', '<?php // Obsolete file');
+        file_put_contents($webDir . '/old-route.php', '<?php // Another obsolete file');
+    }
+
+    public function tearDown(): void
+    {
+        // Clean up test directory
+        if (is_dir($this->fixture)) {
+            $this->recursiveRemoveDirectory($this->fixture);
+        }
+    }
+
+    public function testRemoveObsoleteFiles()
+    {
+        $cleaner = new ObsoleteWebFilesCleaner(
+            ['horde/turba'],
+            $this->fixture
+        );
+
+        // Before cleanup
+        $this->assertFileExists($this->fixture . '/web/turba/index.php');
+        $this->assertFileExists($this->fixture . '/web/turba/browse.php');
+        $this->assertFileExists($this->fixture . '/web/turba/smartmobile.php');
+        $this->assertFileExists($this->fixture . '/web/turba/old-route.php');
+
+        $cleaner->run();
+
+        // After cleanup - files with vendor equivalents should remain
+        $this->assertFileExists($this->fixture . '/web/turba/index.php');
+        $this->assertFileExists($this->fixture . '/web/turba/browse.php');
+
+        // After cleanup - obsolete files should be removed
+        $this->assertFileDoesNotExist($this->fixture . '/web/turba/smartmobile.php');
+        $this->assertFileDoesNotExist($this->fixture . '/web/turba/old-route.php');
+    }
+
+    public function testBrokenSymlinksRemoved()
+    {
+        $webFile = $this->fixture . '/web/turba/broken-link.php';
+        symlink('/nonexistent/path.php', $webFile);
+
+        $this->assertTrue(is_link($webFile));
+        $this->assertFalse(file_exists($webFile));
+
+        $cleaner = new ObsoleteWebFilesCleaner(
+            ['horde/turba'],
+            $this->fixture
+        );
+
+        $cleaner->run();
+
+        // Broken symlink should be removed
+        $this->assertFileDoesNotExist($webFile);
+    }
+
+    public function testNonPhpFilesIgnored()
+    {
+        // Create some non-PHP files
+        file_put_contents($this->fixture . '/web/turba/config.xml', '<config/>');
+        file_put_contents($this->fixture . '/web/turba/style.css', 'body {}');
+
+        $cleaner = new ObsoleteWebFilesCleaner(
+            ['horde/turba'],
+            $this->fixture
+        );
+
+        $cleaner->run();
+
+        // Non-PHP files should not be removed
+        $this->assertFileExists($this->fixture . '/web/turba/config.xml');
+        $this->assertFileExists($this->fixture . '/web/turba/style.css');
+    }
+
+    private function recursiveRemoveDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($directory);
+    }
+}


### PR DESCRIPTION
ObsoleteWebFilesCleaner removes old endpoint files from web/ directories when apps upgrade from exposed PHP files to routes.