### PR TITLE
fix(themes): remove screen.css gate from theme discovery

### DIFF
--- a/src/ThemesHandler.php
+++ b/src/ThemesHandler.php
@@ -93,11 +93,7 @@ class ThemesHandler
                     if (!$theme->isDir() || $theme->isDot()) {
                         continue;
                     }
-                    // Is it really a horde-style theme?
                     $themeSourceDir = $theme->getPathname();
-                    if (!file_exists($themeSourceDir . '/screen.css')) {
-                        continue;
-                    }
                     $themeName = $theme->getFileName();
                     $targetDir =  $this->themesDir . '/' . $packageName . '/' . $themeName;
                     $this->filesystem->ensureDirectoryExists(dirname($targetDir));


### PR DESCRIPTION
## Summary
- Removes the `screen.css` file existence check from `ThemesHandler::setupDefaultTheme()`
- A theme directory's existence under `themes/{name}/` is sufficient for recognition
- Fixes apps like passwd that only ship `responsive.css` or image-only themes not getting symlinked

## Test plan
- [ ] Run `composer horde:reconfigure --force` on an installation with passwd
- [ ] Verify `web/themes/passwd/default` symlink is created
- [ ] Verify no regressions for apps with `screen.css`