### PR TITLE
fix(themes-catalog): rebuild themes.json from scratch on each reconfi…

### DIFF
--- a/src/HordeReconfigureFlow.php
+++ b/src/HordeReconfigureFlow.php
@@ -189,6 +189,8 @@ class HordeReconfigureFlow
             $mode,
         );
 
+        $themesHandler->themesCatalog->reset();
+
         foreach ($hordeThemes as $theme) {
             // register
             [$vendorName, $packageName] = explode('/', $theme);

--- a/src/ThemesCatalog.php
+++ b/src/ThemesCatalog.php
@@ -111,4 +111,15 @@ class ThemesCatalog
     {
         return $this->catalog;
     }
+    
+    /**
+     * Clear the in-memory catalog before a full rebuild.
+     *
+     * Callers are expected to re-register all currently installed
+     * theme packages afterwards and call save().
+     */
+    public function reset(): void
+    {
+        $this->catalog = [];
+    }
 }


### PR DESCRIPTION
## Problem

`themes.json` accumulates stale entries for themes/apps that have been
removed from disk (theme subdir deleted, or theme package uninstalled).
`ThemesCatalog::register()` only adds/overwrites entries, never prunes
them, and `unregister()` is a no-op stub never called with a specific
package. Result: `setupPackagedThemes()` keeps recreating dead symlinks
that `DeadSymlinkCleaner` just removed on the same run.

## Fix

`HordeReconfigureFlow::run()` already computes the authoritative list
of installed theme packages via `InstalledVersions::getInstalledPackagesByType('horde-theme')`
on every run. Add `ThemesCatalog::reset()` and call it before the
register loop, so the catalog is rebuilt from scratch instead of
accreting stale state.

## Testing

Reproduced with a theme package  whose app subdir was removed. 
Before: symlink recreated every run despite DeadSymlinkCleaner.
After: `themes.json` and `web/themes/` stay in sync, no dead symlinks.