### PR TITLE
chore: drop invalid class-style use imports for global functions

### DIFF
--- a/src/HordeReconfigureFlow.php
+++ b/src/HordeReconfigureFlow.php
@@ -18,7 +18,6 @@ use Horde\Composer\IOAdapter\FlowIoInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Horde\Composer\IOAdapter\SymphonyOutputAdapter;
 use RuntimeException;
-use strncasecmp;
 
 use const PHP_OS;
 

--- a/src/ThemesCatalog.php
+++ b/src/ThemesCatalog.php
@@ -6,8 +6,6 @@ namespace Horde\Composer;
 
 use DirectoryIterator;
 use Exception;
-use file_get_contents;
-use json_decode;
 
 /**
  * Encapsulate handling the themes catalog


### PR DESCRIPTION
## Summary

`src/ThemesCatalog.php` had `use file_get_contents;` and `use json_decode;` at the top — `use ClassName;`-style imports of global PHP functions, which are no-ops (function imports need `use function name;`). Both are called unqualified in-body, so they already resolve to the global functions.

As requested, I swept the whole `src/` tree for the same shape and found one more: `use strncasecmp;` in `src/HordeReconfigureFlow.php` (called unqualified on line 71). Also removed.

`use const PHP_OS;` in `HordeReconfigureFlow.php` is a correct const import and was left untouched.

## Changes

- `src/ThemesCatalog.php`: removed `use file_get_contents;` and `use json_decode;`
- `src/HordeReconfigureFlow.php`: removed `use strncasecmp;`

3 deletions, no other changes — behaviourally inert.

## Verification

- `php -l` clean on both files
- Re-ran the grep sweep over `src/`: no class-style function imports remain
- Ran `phpunit`, `php-cs-fixer check` and `phpstan` (level 5) on this branch and on the pristine base: identical results, zero new findings from this change

Closes #23