### PR TITLE
fix(linker): skip sandbox web/var dirs and dangling files

### DIFF
--- a/src/ApplicationLinker.php
+++ b/src/ApplicationLinker.php
@@ -85,6 +85,9 @@ class ApplicationLinker
                     'static', // static should be ensured to exist in webdir.
                     '.git',
                     '.github',
+                    // Local composer sandbox layout; never part of the app source.
+                    'web',
+                    'var',
                 ],
             ];
 
@@ -153,6 +156,9 @@ class ApplicationLinker
                         'migration',
                         'migrations',
                         'examples',
+                        // Local composer sandbox layout; never part of the app source.
+                        'web',
+                        'var',
                     ],
                 ];
                 $this->filesystem->emptyDirectory($appWebDir, true);
@@ -181,6 +187,12 @@ class ApplicationLinker
                     )) {
                         continue;
                     }
+                    $sourceFile = $appVendorDir . DIRECTORY_SEPARATOR . $relativePathName;
+                    // Skip dangling symlinks and other unreadable entries (Composer
+                    // promotes file_get_contents() warnings to ErrorException).
+                    if (!is_file($sourceFile) || !is_readable($sourceFile)) {
+                        continue;
+                    }
                     $this->filesystem->ensureDirectoryExists($appWebDir . DIRECTORY_SEPARATOR . $relativePath);
                     $reflection = new ReflectionMethod($this->filesystem, 'findShortestPath');
                     if ($reflection->getNumberOfParameters() >= 4) {
@@ -206,7 +218,7 @@ class ApplicationLinker
                         );
                     }
 
-                    $originalContent = file_get_contents($appVendorDir . DIRECTORY_SEPARATOR . $relativePathName);
+                    $originalContent = file_get_contents($sourceFile);
                     if ($originalContent === false) {
                         continue;
                     }

--- a/test/ApplicationLinkerTest.php
+++ b/test/ApplicationLinkerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (MIT). If you
+ * did not receive this file, see https://opensource.org/licenses/MIT.
+ *
+ * @author Torben Dannhauer <torben@dannhauer.de>
+ * @category Horde
+ * @copyright 2026 The Horde Project
+ * @license https://opensource.org/licenses/MIT MIT
+ * @package HordeInstallerPlugin
+ */
+
+namespace Horde\Composer\Test;
+
+use Composer\Util\Filesystem;
+use Horde\Composer\ApplicationLinker;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ApplicationLinker::class)]
+class ApplicationLinkerTest extends TestCase
+{
+    private string $tempDir = '';
+    private ?Filesystem $filesystem = null;
+
+    public function setUp(): void
+    {
+        if (!class_exists(Filesystem::class)) {
+            foreach ([
+                dirname(__DIR__) . '/vendor/autoload.php',
+                '/usr/share/php/Composer/autoload.php',
+            ] as $autoload) {
+                if (is_file($autoload)) {
+                    require_once $autoload;
+                }
+                if (class_exists(Filesystem::class)) {
+                    break;
+                }
+            }
+        }
+        if (!class_exists(Filesystem::class)) {
+            $this->markTestSkipped('composer/composer is required to run ApplicationLinker tests');
+        }
+
+        $this->tempDir = sys_get_temp_dir() . '/horde-app-linker-test-' . uniqid();
+        mkdir($this->tempDir);
+        mkdir($this->tempDir . '/vendor', 0o777, true);
+        mkdir($this->tempDir . '/web', 0o777, true);
+        $this->filesystem = new Filesystem();
+    }
+
+    public function tearDown(): void
+    {
+        if ($this->filesystem instanceof Filesystem && $this->tempDir !== '') {
+            $this->filesystem->removeDirectory($this->tempDir);
+        }
+    }
+
+    /**
+     * Accidental sandbox layout (web/, var/) in an app package must not be
+     * copied into web/$app, and dangling JS symlinks under web/ must not abort
+     * proxy-mode linking of the real entry points.
+     */
+    public function testProxyModeSkipsSandboxWebDirAndDanglingSymlinks(): void
+    {
+        $appDir = $this->tempDir . '/vendor/horde/gollem';
+        mkdir($appDir, 0o777, true);
+        file_put_contents($appDir . '/index.php', "<?php\nrequire __DIR__ . '/manager.php';\n");
+        file_put_contents($appDir . '/manager.php', "<?php\necho 'manager';\n");
+
+        $sandboxJs = $appDir . '/web/js/horde';
+        mkdir($sandboxJs, 0o777, true);
+        symlink(
+            '../../../vendor/horde/core/js/accesskeys.js',
+            $sandboxJs . '/accesskeys.js',
+        );
+        mkdir($appDir . '/var/config', 0o777, true);
+        file_put_contents($appDir . '/var/config/horde.local.php', "<?php\n");
+
+        $linker = new ApplicationLinker(
+            $this->filesystem,
+            ['horde/gollem'],
+            $this->tempDir,
+            'proxy',
+        );
+        $linker->run();
+
+        $this->assertFileExists($this->tempDir . '/web/gollem/index.php');
+        $this->assertFileExists($this->tempDir . '/web/gollem/manager.php');
+        $this->assertDirectoryDoesNotExist($this->tempDir . '/web/gollem/web');
+        $this->assertDirectoryDoesNotExist($this->tempDir . '/web/gollem/var');
+        $this->assertFileDoesNotExist($this->tempDir . '/web/gollem/web/js/horde/accesskeys.js');
+    }
+}


### PR DESCRIPTION
## Summary
- Skip accidental `web/` and `var/` sandbox trees when linking Horde apps into `web/$app`
- Skip unreadable files and dangling symlinks instead of aborting `horde:reconfigure`

## Motivation
`composer update` / `horde:reconfigure` failed in proxy mode while linking Gollem:

`file_get_contents(.../vendor/horde/gollem/web/js/horde/accesskeys.js): No such file or directory`

Gollem's `FRAMEWORK_6_0` branch contains leftover Composer sandbox directories (`web/`, `var/`) even though they are listed in `.gitignore`. Those trees include dangling JS symlinks whose relative targets only work at the deployment root.

`ApplicationLinker` empties `web/gollem/` first, then dies on the dangling symlink, so the app has no `index.php`. Apache rewrites `/gollem/` to Rampage, which has no Gollem routes, and the UI shows "No route matched".

## Changes
- Add `web` and `var` to the directory filter in both symlink and proxy modes
- Check `is_file()` / `is_readable()` before `file_get_contents()` so dangling links do not become Composer `ErrorException`s
- Add `ApplicationLinkerTest` covering a Gollem-like sandbox tree with a dangling `web/js/horde/accesskeys.js` symlink

## Test plan
- [ ] `vendor/bin/phpunit -c vendor/horde/horde-installer-plugin/phpunit.xml.dist --bootstrap vendor/autoload.php vendor/horde/horde-installer-plugin/test/ApplicationLinkerTest.php`
- [ ] `composer horde:reconfigure` completes with Gollem (or another app) still containing a leftover `web/` sandbox tree
- [ ] `web/gollem/index.php` exists after reconfigure
- [ ] Opening `/gollem/` in the browser reaches the app (or login), not "No route matched"
